### PR TITLE
Allow mapping to stdClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,3 +674,4 @@ Collection size: 10000
 - [ ] Consider: passing of options to a single mapping operation
 - [x] MapTo: allow mapping of collection
 - [ ] Clean up the property checking in the Mapping::forMember() method.
+- [ ] Refactor tests

--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -98,11 +98,7 @@ class AutoMapper implements AutoMapperInterface
      */
     protected function doMap($source, $destination, MappingInterface $mapping)
     {
-        $propertyNames = $this->autoMapperConfig
-            ->getOptions()
-            ->getPropertyAccessor()
-            ->getPropertyNames($destination);
-
+        $propertyNames = $mapping->getTargetProperties($destination, $source);
         foreach ($propertyNames as $propertyName) {
             $mappingOperation = $mapping->getMappingOperationFor($propertyName);
 

--- a/src/Configuration/Mapping.php
+++ b/src/Configuration/Mapping.php
@@ -187,6 +187,21 @@ class Mapping implements MappingInterface
     /**
      * @inheritdoc
      */
+    public function getTargetProperties($targetObject, $sourceObject): array
+    {
+        $propertyAccessor = $this->options->getPropertyAccessor();
+        if (!$this->options->isObjectCrate($this->destinationClassName)) {
+            $properties = $propertyAccessor->getPropertyNames($targetObject);
+            return array_values($properties);
+        }
+
+        // todo.
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function beConstructedUsing
     (
         callable $factoryCallback

--- a/src/Configuration/MappingInterface.php
+++ b/src/Configuration/MappingInterface.php
@@ -98,6 +98,18 @@ interface MappingInterface
     public function getOptions(): Options;
 
     /**
+     * Returns a list of properties on the target class that will have to be
+     * mapped.
+     * Requires both the source and the target object in case it is an object
+     * crate.
+     *
+     * @param object $targetObject
+     * @param object $sourceObject
+     * @return string[]
+     */
+    public function getTargetProperties($targetObject, $sourceObject): array;
+
+    /**
      * =========================================================================
      * The following methods are purely there for convenience, providing a way
      * to directly configure options.

--- a/src/Configuration/MappingInterface.php
+++ b/src/Configuration/MappingInterface.php
@@ -93,6 +93,20 @@ interface MappingInterface
     ): MappingInterface;
 
     /**
+     * @return Options
+     */
+    public function getOptions(): Options;
+
+    /**
+     * =========================================================================
+     * The following methods are purely there for convenience, providing a way
+     * to directly configure options.
+     * So instead of using $mapping->getOptions()->changeSomeOption(), you can
+     * call $mapping->changeSomeOption() directly.
+     * =========================================================================
+     */
+
+    /**
      * Specifies a custom factory callback to instantiate the destination
      * object. This callback is given the source object as a parameter.
      *
@@ -127,11 +141,6 @@ interface MappingInterface
      * @return MappingInterface
      */
     public function setDefaults(callable $configurator): MappingInterface;
-
-    /**
-     * @return Options
-     */
-    public function getOptions(): Options;
 
     /**
      * Keep in mind that this will override any custom constructor callback set

--- a/src/Configuration/Options.php
+++ b/src/Configuration/Options.php
@@ -56,7 +56,7 @@ class Options
     /**
      * @var string
      */
-    private $objectCrates = [\stdClass::class];
+    private $objectCrates = [];
 
     /**
      * @return Options
@@ -71,6 +71,7 @@ class Options
         $options->setPropertyAccessor(new PropertyAccessor());
         $options->setDefaultMappingOperation(new DefaultMappingOperation());
         $options->setNameResolver(new NameResolver());
+        $options->registerObjectCrate(\stdClass::class);
 
         return $options;
     }

--- a/src/Configuration/Options.php
+++ b/src/Configuration/Options.php
@@ -54,6 +54,11 @@ class Options
     private $customMapper;
 
     /**
+     * @var string
+     */
+    private $objectCrates = [\stdClass::class];
+
+    /**
      * @return Options
      *
      * Note: the skipConstructor default will be replaced by dontSkipConstructor
@@ -222,5 +227,30 @@ class Options
     public function providesCustomMapper(): bool
     {
         return !empty($this->customMapper);
+    }
+
+    /**
+     * @param string $className
+     */
+    public function registerObjectCrate(string $className): void
+    {
+        $this->objectCrates[$className] = true;
+    }
+
+    /**
+     * @param string $className
+     */
+    public function removeObjectCrate(string $className): void
+    {
+        unset($this->objectCrates[$className]);
+    }
+
+    /**
+     * @param string $className
+     * @return bool
+     */
+    public function isObjectCrate(string $className): bool
+    {
+        return isset($this->objectCrates[$className]);
     }
 }

--- a/src/PropertyAccessor/ObjectCratePropertyAccessor.php
+++ b/src/PropertyAccessor/ObjectCratePropertyAccessor.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AutoMapperPlus\PropertyAccessor;
+
+/**
+ * Class ObjectCratePropertyAccessor
+ *
+ * Object crates are objects like stdClass, who just accept any properties you
+ * try to write to them (see #3).
+ *
+ * @package AutoMapperPlus\PropertyAccessor
+ */
+class ObjectCratePropertyAccessor implements PropertyAccessorInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function hasProperty($object, string $propertyName): bool
+    {
+        // We'll assume an object crate always has the desired property.
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getProperty($object, string $propertyName)
+    {
+        return $object->{$propertyName};
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setProperty($object, string $propertyName, $value): void
+    {
+        $object->{$propertyName} = $value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPropertyNames($object): array
+    {
+        // We could alternatively throw an error here, need some more thought.
+        return [];
+    }
+}

--- a/src/PropertyAccessor/PropertyAccessor.php
+++ b/src/PropertyAccessor/PropertyAccessor.php
@@ -108,7 +108,8 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @param string $propertyName
      * @return bool
      */
-    private function isPublic($object, string $propertyName) {
+    private function isPublic($object, string $propertyName)
+    {
         $objectArray = (array) $object;
 
         return array_key_exists($propertyName, $objectArray);

--- a/test/AutoMapperTest.php
+++ b/test/AutoMapperTest.php
@@ -390,9 +390,11 @@ class AutoMapperTest extends TestCase
     {
         $this->config->registerMapping(Source::class, \stdClass::class);
         $mapper = new AutoMapper($this->config);
-        $source = new Source('Some name');
 
+        $source = new Source('Some name');
         $result = $mapper->map($source, \stdClass::class);
+
+        $this->assertTrue(isset($result->name));
         $this->assertEquals($result->name, 'Some name');
     }
 
@@ -404,10 +406,12 @@ class AutoMapperTest extends TestCase
                 new SnakeCaseNamingConvention()
             );
         $mapper = new AutoMapper($this->config);
+
         $source = new CamelCaseSource();
         $source->propertyName = 'Some Name';
-
         $result = $mapper->map($source, \stdClass::class);
+
+        $this->assertTrue(isset($result->property_name));
         $this->assertEquals($result->property_name, 'Some Name');
     }
 
@@ -416,11 +420,12 @@ class AutoMapperTest extends TestCase
         $config =  new AutoMapperConfig();
         $config->getOptions()->registerObjectCrate(NoProperties::class);
         $config->registerMapping(Source::class, NoProperties::class);
-
         $mapper = new AutoMapper($config);
-        $source = new Source('Some name');
 
+        $source = new Source('Some name');
         $result = $mapper->map($source, NoProperties::class);
+
+        $this->assertTrue(isset($result->name));
         $this->assertEquals($result->name, 'Some name');
     }
 
@@ -437,6 +442,8 @@ class AutoMapperTest extends TestCase
         $source->anotherProperty = 'another one';
 
         $result = $mapper->map($source, \stdClass::class);
+
+        $this->assertTrue(isset($result->anotherProperty));
         $this->assertEquals($result->anotherProperty, 'a value');
         $this->assertFalse(isset($result->propertyName));
     }

--- a/test/Configuration/MappingTest.php
+++ b/test/Configuration/MappingTest.php
@@ -327,7 +327,7 @@ class MappingTest extends TestCase
             new SnakeCaseNamingConvention()
         );
 
-        $source = new Source();
+        $source = new CamelCaseSource();
         $target = new Destination();
 
         $this->assertEquals(

--- a/test/Configuration/MappingTest.php
+++ b/test/Configuration/MappingTest.php
@@ -297,4 +297,42 @@ class MappingTest extends TestCase
         $this->assertTrue($mapping->hasCustomConstructor());
         $this->assertEquals($factory, $mapping->getCustomConstructor());
     }
+
+    public function testItCanListTheTargetProperties()
+    {
+        $mapping = new Mapping(
+            Source::class,
+            Destination::class,
+            new AutoMapperConfig()
+        );
+
+        $source = new Source();
+        $target = new Destination();
+
+        $this->assertEquals(
+            ['name', 'anotherProperty'],
+            $mapping->getTargetProperties($target, $source)
+        );
+    }
+
+    public function testItCanListTheTargetPropertiesOfAnObjectCrate()
+    {
+        $mapping = new Mapping(
+            CamelCaseSource::class,
+            \stdClass::class,
+            new AutoMapperConfig()
+        );
+        $mapping->withNamingConventions(
+            new CamelCaseNamingConvention(),
+            new SnakeCaseNamingConvention()
+        );
+
+        $source = new Source();
+        $target = new Destination();
+
+        $this->assertEquals(
+            ['property_name', 'another_property'],
+            $mapping->getTargetProperties($target, $source)
+        );
+    }
 }

--- a/test/Configuration/OptionsTest.php
+++ b/test/Configuration/OptionsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AutoMapperPlus\Configuration;
+
+use AutoMapperPlus\Test\Models\SimpleProperties\Source;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class OptionsTest
+ *
+ * @package AutoMapperPlus\Configuration
+ */
+class OptionsTest extends TestCase
+{
+    public function testItCanRegisterAnObjectCrate()
+    {
+        $options = new Options();
+
+        $this->assertFalse($options->isObjectCrate(Source::class));
+        $options->registerObjectCrate(Source::class);
+        $this->assertTrue($options->isObjectCrate(Source::class));
+    }
+}

--- a/test/Models/SimpleProperties/NoProperties.php
+++ b/test/Models/SimpleProperties/NoProperties.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AutoMapperPlus\Test\Models\SimpleProperties;
+
+/**
+ * Class NoProperties
+ *
+ * @package AutoMapperPlus\Test\Models\SimpleProperties
+ */
+class NoProperties
+{
+    //
+}


### PR DESCRIPTION
As described in #3, this implements mapping to stdClass, and provides a way to register object crates.