### PR TITLE
Add new type of operation similar to MapFrom, but has reference to the mapper instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The following operations are provided:
 | MapTo | Maps the property to another class. Allows for [nested mappings](#dealing-with-nested-mappings). Supports both single values and collections. |
 | FromProperty | Use this to explicitly state the source property name. |
 | DefaultMappingOperation | Simply transfers the property, taking into account the provided naming conventions (if there are any). |
-| MapFromWithMapper | Similar to MapFrom, only in addition to the single parameter, the callback has access to a instance of AutoMapperInterface by specifying the first argument of the callback of AutoMapperInterface type.
+| MapFromWithMapper | Similar to MapFrom.<br>Compared to `mapFrom`, the callback has access to a instance of `AutoMapperInterface`. Define the second callback argument of `AutoMapperInterface` type. Accessible by using <br> - `Operation::mapFromWithMapper(function($source, AutoMapperInterface $mapper){ ... })`<br>- `new mapFromWithMapper(function($source, AutoMapperInterface $mapper){ ... })`
 
 You can use them with the same `forMember()` method. The `Operation` class can
 be used for clarity.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ The following operations are provided:
 | MapTo | Maps the property to another class. Allows for [nested mappings](#dealing-with-nested-mappings). Supports both single values and collections. |
 | FromProperty | Use this to explicitly state the source property name. |
 | DefaultMappingOperation | Simply transfers the property, taking into account the provided naming conventions (if there are any). |
+| MapFromWithMapper | Similar to MapFrom, only in addition to the single parameter, the callback has access to a instance of AutoMapperInterface by specifying the first argument of the callback of AutoMapperInterface type.
 
 You can use them with the same `forMember()` method. The `Operation` class can
 be used for clarity.
@@ -238,6 +239,29 @@ $mapping->forMember('id', Operation::ignore());
 $mapping->forMember('employee', Operation::mapTo(EmployeeDto::class));
 // Explicitly state what the property name is of the source object.
 $mapping->forMember('name', Operation::fromProperty('unconventially_named_property'));
+```
+
+Example of using the MapFromWithMapper:
+```php
+<?php
+
+$getColorPalette = function(AutoMapperInterface $mapper, SimpleXMLElement $XMLElement) { 
+    /** @var SimpleXMLElement $palette */
+    $palette = $XMLElement->xpath('/product/specification/palette/colour');
+
+    return $mapper->mapMultiple($palette, Color::class);
+};
+
+$mapping->forMember('palette', Operation::mapFromWithMapper($getColorPalette));
+
+// or another Example using inline function
+//
+$mapping->forMember('palette', function(AutoMapperInterface $mapper, SimpleXMLElement $XMLElement) { 
+    /** @var SimpleXMLElement $palette */
+    $palette = $XMLElement->xpath('/product/specification/palette/colour');
+
+    return $mapper->mapMultiple($palette, Color::class);
+});
 ```
 
 You can create your own operations by implementing the 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Example of using the MapFromWithMapper:
 ```php
 <?php
 
-$getColorPalette = function(AutoMapperInterface $mapper, SimpleXMLElement $XMLElement) { 
+$getColorPalette = function(SimpleXMLElement $XMLElement, AutoMapperInterface $mapper) { 
     /** @var SimpleXMLElement $palette */
     $palette = $XMLElement->xpath('/product/specification/palette/colour');
 
@@ -256,12 +256,12 @@ $mapping->forMember('palette', Operation::mapFromWithMapper($getColorPalette));
 
 // or another Example using inline function
 //
-$mapping->forMember('palette', function(AutoMapperInterface $mapper, SimpleXMLElement $XMLElement) { 
+$mapping->forMember('palette', new MapFromWithMapper(function(SimpleXMLElement $XMLElement, AutoMapperInterface $mapper) { 
     /** @var SimpleXMLElement $palette */
     $palette = $XMLElement->xpath('/product/specification/palette/colour');
 
     return $mapper->mapMultiple($palette, Color::class);
-});
+}));
 ```
 
 You can create your own operations by implementing the 

--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -6,6 +6,7 @@ use AutoMapperPlus\Configuration\AutoMapperConfig;
 use AutoMapperPlus\Configuration\AutoMapperConfigInterface;
 use AutoMapperPlus\Configuration\MappingInterface;
 use AutoMapperPlus\Exception\UnregisteredMappingException;
+use AutoMapperPlus\MappingOperation\Implementations\MapFromWithMapper;
 use AutoMapperPlus\MappingOperation\Implementations\MapTo;
 use function Functional\map;
 
@@ -108,7 +109,7 @@ class AutoMapper implements AutoMapperInterface
 
             // @todo: find another solution to this hacky implementation of
             // recursive mapping.
-            if ($mappingOperation instanceof MapTo) {
+            if ($mappingOperation instanceof MapTo || $mappingOperation instanceof MapFromWithMapper) {
                 $mappingOperation->setMapper($this);
             }
 

--- a/src/Configuration/Mapping.php
+++ b/src/Configuration/Mapping.php
@@ -6,7 +6,6 @@ use AutoMapperPlus\AutoMapperInterface;
 use AutoMapperPlus\Exception\NoConstructorSetException;
 use AutoMapperPlus\Exception\UnregisteredMappingException;
 use AutoMapperPlus\MapperInterface;
-use AutoMapperPlus\MappingOperation\Implementations\MapFromWithMapper;
 use AutoMapperPlus\MappingOperation\MappingOperationInterface;
 use AutoMapperPlus\MappingOperation\Operation;
 use AutoMapperPlus\MappingOperation\Reversible;
@@ -427,9 +426,9 @@ class Mapping implements MappingInterface
      *
      * @param $operation
      * @param \ReflectionParameter $firstParam
-     * @return MapFromWithMapper
+     * @return MappingOperationInterface
      */
-    private function getOperation_mapFromWithMapper($operation, \ReflectionParameter $firstParam): MapFromWithMapper
+    private function getOperation_mapFromWithMapper($operation, \ReflectionParameter $firstParam): MappingOperationInterface
     {
         if ($firstParam->hasType() === false ||
             $firstParam->getClass()->name !== AutoMapperInterface::class ) {

--- a/src/Configuration/Mapping.php
+++ b/src/Configuration/Mapping.php
@@ -6,7 +6,6 @@ use AutoMapperPlus\AutoMapperInterface;
 use AutoMapperPlus\Exception\NoConstructorSetException;
 use AutoMapperPlus\Exception\UnregisteredMappingException;
 use AutoMapperPlus\MapperInterface;
-use AutoMapperPlus\MappingOperation\DefaultMappingOperation;
 use AutoMapperPlus\MappingOperation\Implementations\MapFromWithMapper;
 use AutoMapperPlus\MappingOperation\MappingOperationInterface;
 use AutoMapperPlus\MappingOperation\Operation;
@@ -398,7 +397,14 @@ class Mapping implements MappingInterface
         return $this->options->getCustomMapper();
     }
 
-    private function getOperationBasedOnArguments($operation):?DefaultMappingOperation
+    /**
+     * Checks the operation passed and returns a instance of MappingOperationInterface
+     *
+     * @param $operation
+     * @return MappingOperationInterface
+     * @throws \ReflectionException
+     */
+    private function getOperationBasedOnArguments($operation):MappingOperationInterface
     {
         $f = new \ReflectionFunction($operation);
         /** @var \ReflectionParameter[] $params */
@@ -414,7 +420,16 @@ class Mapping implements MappingInterface
 
         return $operation;
     }
-    private function getOperation_mapFromWithMapper($operation, \ReflectionParameter $firstParam):?MapFromWithMapper
+
+
+    /**
+     * Checks if the operation passed is a valid callback for mapFromWithMapper operation
+     *
+     * @param $operation
+     * @param \ReflectionParameter $firstParam
+     * @return MapFromWithMapper
+     */
+    private function getOperation_mapFromWithMapper($operation, \ReflectionParameter $firstParam): MapFromWithMapper
     {
         if ($firstParam->hasType() === false ||
             $firstParam->getClass()->name !== AutoMapperInterface::class ) {

--- a/src/Configuration/Mapping.php
+++ b/src/Configuration/Mapping.php
@@ -2,7 +2,6 @@
 
 namespace AutoMapperPlus\Configuration;
 
-use AutoMapperPlus\AutoMapperInterface;
 use AutoMapperPlus\Exception\NoConstructorSetException;
 use AutoMapperPlus\Exception\UnregisteredMappingException;
 use AutoMapperPlus\MapperInterface;
@@ -110,7 +109,7 @@ class Mapping implements MappingInterface
     {
         // If it's just a regular callback, wrap it in an operation.
         if (!$operation instanceof MappingOperationInterface) {
-            $operation = $this->getOperationBasedOnArguments($operation);
+            $operation = Operation::mapFrom($operation);
         }
 
         // Make the config available to the operation.
@@ -394,46 +393,5 @@ class Mapping implements MappingInterface
     public function getCustomMapper(): ?MapperInterface
     {
         return $this->options->getCustomMapper();
-    }
-
-    /**
-     * Checks the operation passed and returns a instance of MappingOperationInterface
-     *
-     * @param $operation
-     * @return MappingOperationInterface
-     * @throws \ReflectionException
-     */
-    private function getOperationBasedOnArguments($operation):MappingOperationInterface
-    {
-        $f = new \ReflectionFunction($operation);
-        /** @var \ReflectionParameter[] $params */
-        $params = $f->getParameters();
-
-        if (count($params) === 0 || count($params) === 1) {
-            $operation = Operation::mapFrom($operation);
-        } elseif (count($params) === 2 ) {
-            $operation = $this->getOperation_mapFromWithMapper($operation, $params[0]);
-        } else {
-            throw new \InvalidArgumentException('AutomapperConfiguration error. Callback must contain 1 or 2 arguments');
-        }
-
-        return $operation;
-    }
-
-
-    /**
-     * Checks if the operation passed is a valid callback for mapFromWithMapper operation
-     *
-     * @param $operation
-     * @param \ReflectionParameter $firstParam
-     * @return MappingOperationInterface
-     */
-    private function getOperation_mapFromWithMapper($operation, \ReflectionParameter $firstParam): MappingOperationInterface
-    {
-        if ($firstParam->hasType() === false ||
-            $firstParam->getClass()->name !== AutoMapperInterface::class ) {
-            throw new \InvalidArgumentException('AutomapperConfiguration error. First argument must be of type AutoMapperInterface');
-        }
-        return Operation::mapFromWithMapper($operation);
     }
 }

--- a/src/Configuration/Mapping.php
+++ b/src/Configuration/Mapping.php
@@ -409,7 +409,7 @@ class Mapping implements MappingInterface
         /** @var \ReflectionParameter[] $params */
         $params = $f->getParameters();
 
-        if (count($params) === 1) {
+        if (count($params) === 0 || count($params) === 1) {
             $operation = Operation::mapFrom($operation);
         } elseif (count($params) === 2 ) {
             $operation = $this->getOperation_mapFromWithMapper($operation, $params[0]);

--- a/src/MappingOperation/Implementations/MapFrom.php
+++ b/src/MappingOperation/Implementations/MapFrom.php
@@ -2,6 +2,7 @@
 
 namespace AutoMapperPlus\MappingOperation\Implementations;
 
+use AutoMapperPlus\AutoMapperInterface;
 use AutoMapperPlus\MappingOperation\DefaultMappingOperation;
 
 /**

--- a/src/MappingOperation/Implementations/MapFrom.php
+++ b/src/MappingOperation/Implementations/MapFrom.php
@@ -14,7 +14,7 @@ class MapFrom extends DefaultMappingOperation
     /**
      * @var callable
      */
-    private $valueCallback;
+    protected $valueCallback;
 
     /**
      * MapFrom constructor.

--- a/src/MappingOperation/Implementations/MapFromWithMapper.php
+++ b/src/MappingOperation/Implementations/MapFromWithMapper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Created by PhpStorm.
- * User: Veaceslav Vasilache <veaceslav.vasilache@amdaris.com>
+ * User: Veaceslav Vasilache <veaceslav.vasilache@gmail.com>
  * Date: 3/14/18
  * Time: 1:16 PM
  */
@@ -9,26 +9,16 @@
 namespace AutoMapperPlus\MappingOperation\Implementations;
 
 use AutoMapperPlus\AutoMapperInterface;
-use AutoMapperPlus\MappingOperation\DefaultMappingOperation;
-
 
 /**
  * Class MapFromWithMapper
  *
  * @package AutoMapperPlus\MappingOperation\Implementations
  */
-class MapFromWithMapper extends DefaultMappingOperation
+class MapFromWithMapper extends MapFrom
 {
-    /** @var callable */
-    private $valueCallback;
-
     /** @var AutoMapperInterface */
     private $mapper;
-
-    public function __construct(callable $valueCallback)
-    {
-        $this->valueCallback = $valueCallback;
-    }
 
     /**
      * @param AutoMapperInterface $mapper
@@ -43,16 +33,6 @@ class MapFromWithMapper extends DefaultMappingOperation
      */
     protected function getSourceValue($source, string $propertyName)
     {
-        return ($this->valueCallback)($this->mapper, $source);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function canMapProperty(string $propertyName, $source): bool
-    {
-        // Mapping with a callback is always possible, regardless of the source
-        // properties.
-        return true;
+        return ($this->valueCallback)($source, $this->mapper);
     }
 }

--- a/src/MappingOperation/Implementations/MapFromWithMapper.php
+++ b/src/MappingOperation/Implementations/MapFromWithMapper.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Veaceslav Vasilache <veaceslav.vasilache@amdaris.com>
+ * Date: 3/14/18
+ * Time: 1:16 PM
+ */
+
+namespace AutoMapperPlus\MappingOperation\Implementations;
+
+use AutoMapperPlus\AutoMapperInterface;
+use AutoMapperPlus\MappingOperation\DefaultMappingOperation;
+
+
+/**
+ * Class MapFromWithMapper
+ *
+ * @package AutoMapperPlus\MappingOperation\Implementations
+ */
+class MapFromWithMapper extends DefaultMappingOperation
+{
+    /** @var callable */
+    private $valueCallback;
+
+    /** @var AutoMapperInterface */
+    private $mapper;
+
+    public function __construct(callable $valueCallback)
+    {
+        $this->valueCallback = $valueCallback;
+    }
+
+    /**
+     * @param AutoMapperInterface $mapper
+     */
+    public function setMapper(AutoMapperInterface $mapper)
+    {
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSourceValue($source, string $propertyName)
+    {
+        return ($this->valueCallback)($this->mapper, $source);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function canMapProperty(string $propertyName, $source): bool
+    {
+        // Mapping with a callback is always possible, regardless of the source
+        // properties.
+        return true;
+    }
+}

--- a/src/MappingOperation/Operation.php
+++ b/src/MappingOperation/Operation.php
@@ -5,6 +5,7 @@ namespace AutoMapperPlus\MappingOperation;
 use AutoMapperPlus\MappingOperation\Implementations\FromProperty;
 use AutoMapperPlus\MappingOperation\Implementations\Ignore;
 use AutoMapperPlus\MappingOperation\Implementations\MapFrom;
+use AutoMapperPlus\MappingOperation\Implementations\MapFromWithMapper;
 use AutoMapperPlus\MappingOperation\Implementations\MapTo;
 
 /**
@@ -26,6 +27,22 @@ class Operation
     public static function mapFrom(callable $valueCallback): MapFrom
     {
         return new MapFrom($valueCallback);
+    }
+
+    /**
+     * Set a property's value from callback, callback should contain 2 parameters
+     *
+     * @param callable $valueCallback
+     *      Callback definition:
+     *
+     *      function(AutoMapperInterface, mixed){
+
+     *      }
+     * @return MapFromWithMapper
+     */
+    public static function mapFromWithMapper(callable $valueCallback): MapFromWithMapper
+    {
+        return new MapFromWithMapper($valueCallback);
     }
 
     /**

--- a/test/AutoMapperTest.php
+++ b/test/AutoMapperTest.php
@@ -456,4 +456,66 @@ class AutoMapperTest extends TestCase
         $result = $mapper->map($source, Destination::class);
         $this->assertEquals(null, $result);
     }
+
+    public function testInvalidWithMappingCallback_ThrowsException()
+    {
+        // Arrange
+        $source = new CamelCaseSource();
+        $error = null;
+
+        // Act
+        try {
+            $this->config->registerMapping(CamelCaseSource::class, \stdClass::class)
+                ->forMember('propertyName', function($mapping, $source){
+                    return 1;
+                });
+            $mapper = new AutoMapper($this->config);
+            $mapper->map($source, \stdClass::class);
+        } catch (\Exception $error){
+        }
+
+        // Assert
+        $this->assertInstanceOf(\InvalidArgumentException::class, $error);
+        $this->assertStringEndsWith('First argument must be of type AutoMapperInterface',$error->getMessage());
+    }
+
+    public function testInstanceWithMappingCallback_InstanceIsCorrect()
+    {
+        // Arrange
+        $this->config->registerMapping(CamelCaseSource::class, \stdClass::class)
+            ->forMember('propertyName', function(AutoMapperInterface $mapping, $source){
+                // if the $mapping isn't a instance of AutoMapperInterface, it wouldn't return anything
+                return 13;
+            });
+        $mapper = new AutoMapper($this->config);
+        $source = new CamelCaseSource();
+
+        // Act
+        $result = $mapper->map($source, \stdClass::class);
+
+        // Assert
+        $this->assertEquals(13, $result->propertyName);
+    }
+
+    public function testCallbackWith3ArgumentsInMapFrom_ThrowsException()
+    {
+        // Arrange
+        $source = new CamelCaseSource();
+        $error = null;
+
+        // Act
+        try {
+            $this->config->registerMapping(CamelCaseSource::class, \stdClass::class)
+                ->forMember('propertyName', function($mapping, $source, $thirdArgument){
+                    return 1;
+                });
+            $mapper = new AutoMapper($this->config);
+            $mapper->map($source, \stdClass::class);
+        } catch (\Exception $error){
+        }
+
+        // Assert
+        $this->assertInstanceOf(\InvalidArgumentException::class, $error);
+        $this->assertStringEndsWith('Callback must contain 1 or 2 arguments',$error->getMessage());
+    }
 }

--- a/test/MappingOperation/Implementations/MapFromWithMappingTest.php
+++ b/test/MappingOperation/Implementations/MapFromWithMappingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace AutoMapperPlus\MappingOperation\Implementations;
+
+use AutoMapperPlus\AutoMapper;
+use AutoMapperPlus\AutoMapperInterface;
+use AutoMapperPlus\Configuration\AutoMapperConfigInterface;
+use AutoMapperPlus\Configuration\Options;
+use PHPUnit\Framework\TestCase;
+use AutoMapperPlus\Test\Models\SimpleProperties\Destination;
+use AutoMapperPlus\Test\Models\SimpleProperties\Source;
+
+/**
+ * Class MapFromTest
+ *
+ * @package AutoMapperPlus\MappingOperation\Implementations
+ * @group mappingOperations
+ */
+class MapFromWithMapperTest extends TestCase
+{
+    public function testItMapsFromACallback()
+    {
+        // Arrange
+        $mapFromWithMapper = new MapFromWithMapper(function (AutoMapperInterface $mapper, $source) {
+            return 42;
+        });
+        $mapFromWithMapper->setMapper(AutoMapper::initialize(function (AutoMapperConfigInterface $config) {
+            $config->registerMapping(Source::class, Destination::class);
+        }));
+        $mapFromWithMapper->setOptions(Options::default());
+
+        $source = new Source();
+        $destination = new Destination();
+
+        // Act
+        $mapFromWithMapper->mapProperty('name', $source, $destination);
+
+        // Assert
+        $this->assertEquals(42, $destination->name);
+    }
+
+    public function testItReceivesTheSourceObject()
+    {
+        // Arrange
+        $mapFromWithMapper = new MapFromWithMapper(function (AutoMapperInterface $mapper, $source) {
+            return $source;
+        });
+        $mapFromWithMapper->setMapper(AutoMapper::initialize(function (AutoMapperConfigInterface $config) {
+            $config->registerMapping(Source::class, Destination::class);
+        }));
+        $mapFromWithMapper->setOptions(Options::default());
+
+        $source = new Source();
+        $destination = new Destination();
+
+        // Act
+        $mapFromWithMapper->mapProperty('name', $source, $destination);
+
+        // Assert
+        $this->assertInstanceOf(Source::class, $destination->name);
+    }
+}

--- a/test/MappingOperation/Implementations/MapFromWithMappingTest.php
+++ b/test/MappingOperation/Implementations/MapFromWithMappingTest.php
@@ -11,7 +11,7 @@ use AutoMapperPlus\Test\Models\SimpleProperties\Destination;
 use AutoMapperPlus\Test\Models\SimpleProperties\Source;
 
 /**
- * Class MapFromTest
+ * Class MapFromWithMapperTest
  *
  * @package AutoMapperPlus\MappingOperation\Implementations
  * @group mappingOperations
@@ -21,7 +21,7 @@ class MapFromWithMapperTest extends TestCase
     public function testItMapsFromACallback()
     {
         // Arrange
-        $mapFromWithMapper = new MapFromWithMapper(function (AutoMapperInterface $mapper, $source) {
+        $mapFromWithMapper = new MapFromWithMapper(function ($source, AutoMapperInterface $mapper) {
             return 42;
         });
         $mapFromWithMapper->setMapper(AutoMapper::initialize(function (AutoMapperConfigInterface $config) {
@@ -42,7 +42,7 @@ class MapFromWithMapperTest extends TestCase
     public function testItReceivesTheSourceObject()
     {
         // Arrange
-        $mapFromWithMapper = new MapFromWithMapper(function (AutoMapperInterface $mapper, $source) {
+        $mapFromWithMapper = new MapFromWithMapper(function ($source, AutoMapperInterface $mapper) {
             return $source;
         });
         $mapFromWithMapper->setMapper(AutoMapper::initialize(function (AutoMapperConfigInterface $config) {


### PR DESCRIPTION
Add new type of operation similar to **MapFrom** operation, but has reference to the mapper instance through first argument.
Allows to customize the mapping when the object structure isn't obvious and can't be predicted automatically by Automapper