### PR TITLE
Add MapperAware functionality to customAutomapper classes

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -55,7 +55,7 @@ class AutoMapper implements AutoMapperInterface
 
         $mapping = $this->getMapping($sourceClass, $destinationClass);
         if ($mapping->providesCustomMapper()) {
-            return $mapping->getCustomMapper()->map($source, $destinationClass);
+            return $this->getCustomMapper($mapping)->map($source, $destinationClass);
         }
 
         $destinationObject = $mapping->hasCustomConstructor()
@@ -85,7 +85,7 @@ class AutoMapper implements AutoMapperInterface
 
         $mapping = $this->getMapping($sourceClassName, $destinationClassName);
         if ($mapping->providesCustomMapper()) {
-            return $mapping->getCustomMapper()->mapToObject($source, $destination);
+            return $this->getCustomMapper($mapping)->mapToObject($source, $destination);
         }
 
         return $this->doMap($source, $destination, $mapping);
@@ -152,5 +152,22 @@ class AutoMapper implements AutoMapperInterface
             $sourceClass,
             $destinationClass
         );
+    }
+
+    /**
+     * Gets the custom
+     * @param MappingInterface $mapping
+     *
+     * @return MapperInterface|null
+     */
+    private function getCustomMapper(MappingInterface $mapping)
+    {
+        $customMapper = $mapping->getCustomMapper();
+
+        if ($customMapper instanceof MapperAwareOperation) {
+            $customMapper->setMapper($this);
+        }
+
+        return $customMapper;
     }
 }

--- a/src/MapperAware.php
+++ b/src/MapperAware.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: slava
+ * Date: 6/10/18
+ * Time: 3:27 PM
+ */
+
+namespace AutoMapperPlus;
+
+/**
+ * Interface MapperAware
+ *
+ * @package AutoMapperPlus
+ */
+interface MapperAware
+{
+    /**
+     * @param AutoMapperInterface $mapper
+     */
+    public function setMapper(AutoMapperInterface $mapper): void;
+}

--- a/src/MappingOperation/MapperAwareOperation.php
+++ b/src/MappingOperation/MapperAwareOperation.php
@@ -2,16 +2,13 @@
 
 namespace AutoMapperPlus\MappingOperation;
 
-use AutoMapperPlus\AutoMapperInterface;
+use AutoMapperPlus\MapperAware;
 
 /**
  * Interface MapperAwareOperation
  *
  * @package AutoMapperPlus\MappingOperation
  */
-interface MapperAwareOperation {
-    /**
-     * @param AutoMapperInterface $mapper
-     */
-    public function setMapper(AutoMapperInterface $mapper): void;
+interface MapperAwareOperation extends MapperAware
+{
 }

--- a/test/CustomMapper/EmployeeMapperWithMapperAware.php
+++ b/test/CustomMapper/EmployeeMapperWithMapperAware.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AutoMapperPlus\Test\CustomMapper;
+
+use AutoMapperPlus\CustomMapper\CustomMapper;
+use AutoMapperPlus\MappingOperation\MapperAwareOperation;
+use AutoMapperPlus\MappingOperation\MapperAwareTrait;
+use AutoMapperPlus\Test\Models\Employee\Employee;
+use AutoMapperPlus\Test\Models\Employee\EmployeeDto;
+use AutoMapperPlus\Test\Models\Nested\AddressDto;
+
+/**
+ * Class EmployeeMapper
+ *
+ * @package AutoMapperPlus\Test\CustomMapper
+ */
+class EmployeeMapperWithMapperAware extends CustomMapper implements MapperAwareOperation
+{
+    use MapperAwareTrait;
+
+    /**
+     * @param Employee    $source
+     * @param EmployeeDto $destination
+     *
+     * @return EmployeeDto
+     * @throws \AutoMapperPlus\Exception\UnregisteredMappingException
+     */
+    public function mapToObject($source, $destination)
+    {
+        $destination->id = $source->getId();
+        $destination->firstName = $source->getFirstName();
+        $destination->lastName = $source->getLastName();
+        $destination->age = date('Y') - $source->getBirthYear();
+        $destination->notes = 'Mapped by EmployeeMapperWithMapperAware';
+
+        $destination->address = $this->mapper->map($source->getAddress(), AddressDto::class);
+
+        return $destination;
+    }
+}

--- a/test/Models/Employee/Employee.php
+++ b/test/Models/Employee/Employee.php
@@ -13,13 +13,15 @@ class Employee
     private $firstName;
     private $lastName;
     private $birthYear;
+    private $address;
 
-    function __construct(int $id, string $firstName, string $lastName, int $birthYear)
+    function __construct(int $id, string $firstName, string $lastName, int $birthYear, $address = null)
     {
         $this->id = $id;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
         $this->birthYear = $birthYear;
+        $this->address = $address;
     }
 
     /**
@@ -84,5 +86,21 @@ class Employee
     public function setBirthYear($birthYear)
     {
         $this->birthYear = $birthYear;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * @param mixed $address
+     */
+    public function setAddress($address)
+    {
+        $this->address = $address;
     }
 }

--- a/test/Models/Employee/EmployeeDto.php
+++ b/test/Models/Employee/EmployeeDto.php
@@ -9,4 +9,5 @@ class EmployeeDto
     public $lastName;
     public $age;
     public $notes;
+    public $address;
 }


### PR DESCRIPTION
Add `MapperAwareOperation` interface handling for `CustomAutomapper` classes

I assume the `MapperAwareOperation` interface could be moved up a level and renamed accordingly because it's not related only to mapping operations. But I wait for your suggestions and comments