### PR TITLE
Pass mapper to a custom constructor callable

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -59,7 +59,7 @@ class AutoMapper implements AutoMapperInterface
         }
 
         $destinationObject = $mapping->hasCustomConstructor()
-            ? $mapping->getCustomConstructor()($source)
+            ? $mapping->getCustomConstructor()($source, $this)
             : new $destinationClass;
 
         return $this->doMap($source, $destinationObject, $mapping);

--- a/test/AutoMapperTest.php
+++ b/test/AutoMapperTest.php
@@ -400,7 +400,7 @@ class AutoMapperTest extends TestCase
     public function testACustomConstructorCallbackCanBeProvided()
     {
         $this->config->registerMapping(Source::class, Destination::class)
-            ->beConstructedUsing(function (Source $source): Destination {
+            ->beConstructedUsing(function (Source $source, AutoMapperInterface $mapper): Destination {
                 return new Destination('Set during construct');
             })
             ->forMember('name', Operation::ignore());


### PR DESCRIPTION
```php
$config
    ->registerMapping(Entity::class, DTO::class)
    ->reverseMap()
    ->beConstructedUsing(function (DTO $model, AutoMapperInterface $mapper) {
        $object = new Entity(
            $mapper->map($model->foo, Foo::class)
        );

         return $object;
    })
;
```

Second argument `AutoMapperInterface $mapper` can be omitted, so no BC brake here