### PR TITLE
Add validation to mapMultiple operation

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -6,6 +6,7 @@ use AutoMapperPlus\Configuration\AutoMapperConfig;
 use AutoMapperPlus\Configuration\AutoMapperConfigInterface;
 use AutoMapperPlus\Configuration\MappingInterface;
 use AutoMapperPlus\Exception\AutoMapperPlusException;
+use AutoMapperPlus\Exception\InvalidArgumentException;
 use AutoMapperPlus\Exception\UnregisteredMappingException;
 use AutoMapperPlus\MappingOperation\ContextAwareOperation;
 use AutoMapperPlus\MappingOperation\MapperAwareOperation;
@@ -96,6 +97,13 @@ class AutoMapper implements AutoMapperInterface
         string $destinationClass,
         array $context = []
     ): array {
+
+        if(!is_iterable($sourceCollection)){
+            throw new InvalidArgumentException(
+                'The collection provided should be iterable.'
+            );
+        }
+
         $mappedResults = [];
         foreach ($sourceCollection as $source) {
             $mappedResults[] = $this->map($source, $destinationClass, $context);

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AutoMapperPlus\Exception;
+
+/**
+ * Class InvalidArgumentException
+ *
+ * @package AutoMapperPlus\Exception
+ */
+class InvalidArgumentException extends AutoMapperPlusException
+{
+}

--- a/test/AutoMapperTest.php
+++ b/test/AutoMapperTest.php
@@ -43,6 +43,7 @@ use AutoMapperPlus\Test\Models\SpecialConstructor\Destination as ConstructorDest
 use AutoMapperPlus\Test\Models\Visibility\Visibility;
 use AutoMapperPlus\Test\Models\SimilarPropertyNames\Source as SimilarSource;
 use AutoMapperPlus\Test\Models\SimilarPropertyNames\Destination as SimilarDestination;
+use AutoMapperPlus\Exception\InvalidArgumentException;
 
 /**
  * Class AutoMapperTest
@@ -720,5 +721,17 @@ class AutoMapperTest extends TestCase
         $result = $mapper->map($source, Destination::class);
 
         $this->assertEquals('a name', $result->name);
+    }
+
+    public function testAnExceptionIsThrownForNoIterableSourceInMultpleMappings()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->config->registerMapping(Source::class, Destination::class);
+        $mapper = new AutoMapper($this->config);
+
+        $sourceCollection = new \stdClass();
+        
+        $mapper->mapMultiple($sourceCollection, Destination::class);
     }
 }


### PR DESCRIPTION
Verify if the sourceCollection is iterable before passing it to the foreach.