### PR TITLE
Allow mapping of an array into an existing object

### DIFF
--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -59,7 +59,7 @@ class AutoMapper implements AutoMapperInterface
             $sourceClass = \get_class($source);
         }
         else {
-            $sourceClass= \gettype($source);
+            $sourceClass = \gettype($source);
             if ($sourceClass !== DataType::ARRAY) {
                 throw new AutoMapperPlusException(
                     'Mapping from something else than an object or array is not supported yet.'
@@ -117,10 +117,21 @@ class AutoMapper implements AutoMapperInterface
      */
     public function mapToObject($source, $destination, array $context = [])
     {
-        $sourceClassName = \get_class($source);
-        $destinationClassName = \get_class($destination);
+        if (\is_object($source)) {
+            $sourceClass = \get_class($source);
+        }
+        else {
+            $sourceClass = \gettype($source);
+            if ($sourceClass !== DataType::ARRAY) {
+                throw new AutoMapperPlusException(
+                    'Mapping from something else than an object or array is not supported yet.'
+                );
+            }
+        }
 
-        $mapping = $this->getMapping($sourceClassName, $destinationClassName);
+        $destinationClass = \get_class($destination);
+
+        $mapping = $this->getMapping($sourceClass, $destinationClass);
         if ($mapping->providesCustomMapper()) {
             return $this->getCustomMapper($mapping)->mapToObject($source, $destination, [
                 self::DESTINATION_CONTEXT => $destination,

--- a/src/AutoMapper.php
+++ b/src/AutoMapper.php
@@ -8,6 +8,7 @@ use AutoMapperPlus\Configuration\MappingInterface;
 use AutoMapperPlus\Exception\AutoMapperPlusException;
 use AutoMapperPlus\Exception\InvalidArgumentException;
 use AutoMapperPlus\Exception\UnregisteredMappingException;
+use AutoMapperPlus\Exception\UnsupportedSourceTypeException;
 use AutoMapperPlus\MappingOperation\ContextAwareOperation;
 use AutoMapperPlus\MappingOperation\MapperAwareOperation;
 
@@ -61,9 +62,7 @@ class AutoMapper implements AutoMapperInterface
         else {
             $sourceClass = \gettype($source);
             if ($sourceClass !== DataType::ARRAY) {
-                throw new AutoMapperPlusException(
-                    'Mapping from something else than an object or array is not supported yet.'
-                );
+                throw UnsupportedSourceTypeException::fromType($sourceClass);
             }
         }
 
@@ -123,9 +122,7 @@ class AutoMapper implements AutoMapperInterface
         else {
             $sourceClass = \gettype($source);
             if ($sourceClass !== DataType::ARRAY) {
-                throw new AutoMapperPlusException(
-                    'Mapping from something else than an object or array is not supported yet.'
-                );
+                throw UnsupportedSourceTypeException::fromType($sourceClass);
             }
         }
 

--- a/src/Exception/UnsupportedSourceTypeException.php
+++ b/src/Exception/UnsupportedSourceTypeException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AutoMapperPlus\Exception;
+
+class UnsupportedSourceTypeException extends AutoMapperPlusException
+{
+    /**
+     * @param string $type
+     * @return UnsupportedSourceTypeException
+     */
+    public static function fromType($type): UnsupportedSourceTypeException
+    {
+        $message = sprintf('Expected object or array as a source, got %s.', $type);
+
+        return new static($message);
+    }
+}

--- a/src/MapperInterface.php
+++ b/src/MapperInterface.php
@@ -15,7 +15,7 @@ interface MapperInterface
      * Maps an object to an instance of class $to, provided a mapping is
      * configured.
      *
-     * @param $source
+     * @param array|object $source
      *   The source object.
      * @param string $targetClass
      *   The target classname.
@@ -34,9 +34,9 @@ interface MapperInterface
     /**
      * Maps properties of object $from to an existing object $to.
      *
-     * @param $source
+     * @param array|object $source
      *   The source object.
-     * @param $destination
+     * @param object $destination
      *   The target object.
      * @param array $context
      *   See MapperInterface::map()


### PR DESCRIPTION
Hi,

The library currently allows using array as a source for `->map`, but not for `->mapToObject`. This PR allows to do so.