### PR TITLE
Add middleware feature (extensions)

### DIFF
--- a/src/Configuration/AutoMapperConfig.php
+++ b/src/Configuration/AutoMapperConfig.php
@@ -2,6 +2,10 @@
 
 namespace AutoMapperPlus\Configuration;
 
+use AutoMapperPlus\Middleware\MapperMiddleware;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
 /**
  * Class AutoMapperConfig
  *
@@ -13,6 +17,16 @@ class AutoMapperConfig implements AutoMapperConfigInterface
      * @var MappingInterface[]
      */
     private $mappings = [];
+
+    /**
+     * @var MapperMiddleware[]
+     */
+    private $mapperMiddlewares = [];
+
+    /**
+     * @var PropertyMiddleware[]
+     */
+    private $propertyMiddlewares = [];
 
     /**
      * @var Options
@@ -38,7 +52,8 @@ class AutoMapperConfig implements AutoMapperConfigInterface
     public function hasMappingFor(
         string $sourceClassName,
         string $destinationClassName
-    ): bool {
+    ): bool
+    {
         $mapping = $this->getMappingFor(
             $sourceClassName,
             $destinationClassName
@@ -53,7 +68,8 @@ class AutoMapperConfig implements AutoMapperConfigInterface
     public function getMappingFor(
         string $sourceClassName,
         string $destinationClassName
-    ): ?MappingInterface {
+    ): ?MappingInterface
+    {
         // Check for an exact match before we try parent classes.
         foreach ($this->mappings as $mapping) {
             $isExactMatch = $mapping->getSourceClassName() === $sourceClassName
@@ -120,11 +136,12 @@ class AutoMapperConfig implements AutoMapperConfigInterface
         array $candidates,
         string $sourceClassName,
         string $destinationClassName
-    ): ?MappingInterface {
+    ): ?MappingInterface
+    {
         $lowestDistance = PHP_INT_MAX;
         $selectedCandidate = null;
         /** @var MappingInterface $candidate */
-        foreach($candidates as $candidate) {
+        foreach ($candidates as $candidate) {
             $sourceDistance = $this->getClassDistance(
                 $sourceClassName,
                 $candidate->getSourceClassName()
@@ -154,14 +171,15 @@ class AutoMapperConfig implements AutoMapperConfigInterface
     protected function getClassDistance(
         string $childClass,
         string $parentClass
-    ): int {
+    ): int
+    {
         if ($childClass === $parentClass) {
             return 0;
         }
 
         $result = 0;
         $childParents = class_parents($childClass, true);
-        foreach($childParents as $childParent) {
+        foreach ($childParents as $childParent) {
             $result++;
             if ($childParent === $parentClass) {
                 return $result;
@@ -194,7 +212,8 @@ class AutoMapperConfig implements AutoMapperConfigInterface
     public function registerMapping(
         string $sourceClassName,
         string $destinationClassName
-    ): MappingInterface {
+    ): MappingInterface
+    {
         $mapping = new Mapping(
             $sourceClassName,
             $destinationClassName,
@@ -205,11 +224,40 @@ class AutoMapperConfig implements AutoMapperConfigInterface
         return $mapping;
     }
 
+    public function registerMiddlewares(Middleware ...$middlewares): void
+    {
+        foreach ($middlewares as $middleware) {
+            if ($middleware instanceof MapperMiddleware) {
+                $this->mapperMiddlewares[] = $middleware;
+            }
+            if ($middleware instanceof PropertyMiddleware) {
+                $this->propertyMiddlewares[] = $middleware;
+            }
+        }
+    }
+
+
     /**
      * @inheritdoc
      */
     public function getOptions(): Options
     {
         return $this->options;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMapperMiddlewares()
+    {
+        return $this->mapperMiddlewares;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPropertyMiddlewares()
+    {
+        return $this->propertyMiddlewares;
     }
 }

--- a/src/Configuration/AutoMapperConfigInterface.php
+++ b/src/Configuration/AutoMapperConfigInterface.php
@@ -2,6 +2,10 @@
 
 namespace AutoMapperPlus\Configuration;
 
+use AutoMapperPlus\Middleware\MapperMiddleware;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
 /**
  * Interface AutoMapperConfigInterface
  *
@@ -48,7 +52,25 @@ interface AutoMapperConfigInterface
     ): MappingInterface;
 
     /**
+     * Register middlewares.
+     *
+     * @param Middleware ...$middlewares
+     * @return void
+     */
+    public function registerMiddlewares(Middleware ...$middlewares): void;
+
+    /**
      * @return Options
      */
     public function getOptions(): Options;
+
+    /**
+     * @return MapperMiddleware[]
+     */
+    public function getMapperMiddlewares();
+
+    /**
+     * @return PropertyMiddleware[]
+     */
+    public function getPropertyMiddlewares();
 }

--- a/src/Middleware/MapperMiddleware.php
+++ b/src/Middleware/MapperMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace AutoMapperPlus\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+
+interface MapperMiddleware extends Middleware
+{
+    /**
+     * Check is this middleware supports the current object mapping request, and where it should inject into the
+     * standard behavior.
+     *
+     * @param $source
+     * @param $destination
+     * @param MappingInterface $mapping
+     * @param array $context
+     * @return int|bool {Middleware::AFTER, Middleware::BEFORE, Middleware::SKIP, Middleware::OVERRIDE}
+     */
+    public function supportsMap(
+        $source,
+        $destination,
+        MappingInterface $mapping,
+        array $context = []);
+
+    /**
+     * Perform a custom object mapping job.
+     * 
+     * It will be not be invoked at all if supportsMapProperty returns Middleware::SKIP or false.
+     * It will be invoked after the standard behavior if supportsMapProperty returns Middleware::AFTER or true.
+     * It will be invoked before the standard behavior if supportsMapProperty returns Middleware:BEFORE.
+     * It will be invoked in replacement of standard behavior if supportsMapProperty returns Middleware:OVERRIDE.
+     *
+     * @param $source
+     * @param $destination
+     * @param MappingInterface $mapping
+     * @param array $context
+     * @return mixed
+     */
+    public function map(
+        $source,
+        $destination,
+        MappingInterface $mapping,
+        array $context = []
+    );
+}

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace AutoMapperPlus\Middleware;
+
+
+interface Middleware
+{
+    /**
+     * The middleware implementation will replace the standard behavior.
+     * 
+     * @see MapperMiddleware::supports()
+     */
+    const OVERRIDE = PHP_INT_MAX;
+
+    /**
+     * The middleware implementation will not be used at all.
+     * 
+     * @see MapperMiddleware::supports()
+     */
+    const SKIP = 0;
+
+    /**
+     * The middleware implementation will be invoked after the standard behavior.
+     * 
+     * @see MapperMiddleware::supportsMap()
+     * @see PropertyMiddleware::supportsMapProperty()
+     */
+    const AFTER = 1;
+
+    /**
+     * The middleware implementation will be invoked before the standard behavior.
+     * 
+     * @see MapperMiddleware::supportsMap()
+     * @see PropertyMiddleware::supportsMapProperty()
+     */
+    const BEFORE = -1;
+}

--- a/src/Middleware/PropertyMiddleware.php
+++ b/src/Middleware/PropertyMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace AutoMapperPlus\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\MapperInterface;
+use AutoMapperPlus\MappingOperation\MappingOperationInterface;
+
+interface PropertyMiddleware extends Middleware
+{
+    /**
+     * Check is this middleware supports the current property mapping request, and where it should inject into the
+     * standard behavior.
+     *
+     * @param $propertyName
+     * @param $source
+     * @param $destination
+     * @param MappingInterface $mapping
+     * @param MappingOperationInterface $operation
+     * @param array $context
+     * @return int|bool {Middleware::AFTER, Middleware::BEFORE, Middleware::SKIP, Middleware::OVERRIDE}
+     */
+    public function supportsMapProperty(
+        $propertyName,
+        $source,
+        $destination,
+        MappingInterface $mapping,
+        MappingOperationInterface $operation,
+        array $context = []);
+
+    /**
+     * Perform a custom property mapping job.
+     *
+     * It will be not be invoked at all if supportsMapProperty returns Middleware::SKIP or false.
+     * It will be invoked after the standard behavior if supportsMapProperty returns Middleware::AFTER or true.
+     * It will be invoked before the standard behavior if supportsMapProperty returns Middleware:BEFORE.
+     * It will be invoked in replacement of standard behavior if supportsMapProperty returns Middleware:OVERRIDE.
+     *
+     * @param $propertyName
+     * @param $source
+     * @param $destination
+     * @param MappingInterface $mapping
+     * @param MappingOperationInterface $operation
+     * @param array $context
+     * @return mixed
+     */
+    public function mapProperty(
+        $propertyName,
+        $source,
+        $destination,
+        MappingInterface $mapping,
+        MappingOperationInterface $operation,
+        array $context = []
+    );
+
+}

--- a/test/Middleware/AnwserToUniverseMiddleware.php
+++ b/test/Middleware/AnwserToUniverseMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\MappingOperation\MappingOperationInterface;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
+class AnwserToUniverseMiddleware implements PropertyMiddleware
+{
+    public function supportsMapProperty($propertyName,
+                                        $source,
+                                        $destination,
+                                        MappingInterface $mapping,
+                                        MappingOperationInterface $operation,
+                                        array $context = [])
+    {
+        return $propertyName == 'id';
+    }
+
+    public function mapProperty($propertyName,
+                                $source,
+                                $destination,
+                                MappingInterface $mapping,
+                                MappingOperationInterface $operation,
+                                array $context = [])
+    {
+        $defaultValue = $mapping->getOptions()->getPropertyReader()->getProperty($destination, $propertyName);
+        if ($defaultValue === NULL) {
+            $mapping->getOptions()->getPropertyWriter()->setProperty($destination, $propertyName, 42);
+        }
+    }
+}

--- a/test/Middleware/AppendMapperMiddleware.php
+++ b/test/Middleware/AppendMapperMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\Middleware\MapperMiddleware;
+use AutoMapperPlus\Middleware\Middleware;
+
+class AppendMapperMiddleware implements MapperMiddleware
+{
+    private $append;
+    private $supportsValue;
+
+    public function __construct(string $append = ' (append)', int $supportsValue = Middleware::AFTER)
+    {
+        $this->append = $append;
+        $this->supportsValue = $supportsValue;
+    }
+
+    public function supportsMap($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        return $this->supportsValue;
+    }
+
+    public function map($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        $destination->name = $destination->name . $this->append;
+    }
+}

--- a/test/Middleware/AppendPropertyMiddleware.php
+++ b/test/Middleware/AppendPropertyMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\MappingOperation\MappingOperationInterface;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
+class AppendPropertyMiddleware implements PropertyMiddleware
+{
+    private $append;
+    private $supportsValue;
+
+    public function __construct($append = ' (append)', int $supportsValue = Middleware::AFTER)
+    {
+        $this->append = $append;
+        $this->supportsValue = $supportsValue;
+    }
+
+    public function supportsMapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        return $propertyName == 'name' ? $this->supportsValue : Middleware::SKIP;
+    }
+
+    public function mapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        $destination->{$propertyName} = $destination->{$propertyName} . $this->append;
+    }
+}

--- a/test/Middleware/BeforeMapperMiddleware.php
+++ b/test/Middleware/BeforeMapperMiddleware.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\Middleware\MapperMiddleware;
+use AutoMapperPlus\Middleware\Middleware;
+
+class BeforeMapperMiddleware implements MapperMiddleware
+{
+    public function supportsMap($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        return Middleware::BEFORE;
+    }
+
+    public function map($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        $destination->name = 'This should never appear';
+    }
+}

--- a/test/Middleware/BeforePropertyMiddleware.php
+++ b/test/Middleware/BeforePropertyMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\MappingOperation\MappingOperationInterface;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
+class BeforePropertyMiddleware implements PropertyMiddleware
+{
+    public function supportsMapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        if ($propertyName == 'name') {
+            return Middleware::BEFORE;
+        }
+    }
+
+    public function mapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        $destination->{$propertyName} = 'This should never appear';
+    }
+}

--- a/test/Middleware/NoopMapperMiddleware.php
+++ b/test/Middleware/NoopMapperMiddleware.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\Middleware\MapperMiddleware;
+use AutoMapperPlus\Middleware\Middleware;
+
+class NoopMapperMiddleware implements MapperMiddleware
+{
+    private $supportsValue;
+
+    public function __construct($supportsValue = Middleware::OVERRIDE)
+    {
+        $this->supportsValue = $supportsValue;
+    }
+
+    public function supportsMap($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        return $this->supportsValue;
+    }
+
+    public function map($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        //NOOP
+    }
+}

--- a/test/Middleware/NoopPropertyMiddleware.php
+++ b/test/Middleware/NoopPropertyMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\MappingOperation\MappingOperationInterface;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
+class NoopPropertyMiddleware implements PropertyMiddleware
+{
+    private $supportsValue;
+
+    public function __construct($supportsValue = Middleware::OVERRIDE)
+    {
+        $this->supportsValue = $supportsValue;
+    }
+
+    public function supportsMapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        return $propertyName == 'name' ? $this->supportsValue : false;
+    }
+
+    public function mapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        //NOOP
+    }
+}

--- a/test/Middleware/SkipMapperMiddleware.php
+++ b/test/Middleware/SkipMapperMiddleware.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\Middleware\MapperMiddleware;
+use AutoMapperPlus\Middleware\Middleware;
+
+class SkipMapperMiddleware implements MapperMiddleware
+{
+    public function supportsMap($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        return Middleware::SKIP;
+    }
+
+    public function map($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        $destination->name = 'This should never happen';
+    }
+}

--- a/test/Middleware/SkipPropertyMiddleware.php
+++ b/test/Middleware/SkipPropertyMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\MappingOperation\MappingOperationInterface;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
+class SkipPropertyMiddleware implements PropertyMiddleware
+{
+    public function supportsMapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        return $propertyName == 'name' ? Middleware::SKIP : true;
+    }
+
+    public function mapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        $destination->{$propertyName} = 'This should happen unless it is name property';
+    }
+}

--- a/test/Middleware/ValueMapperMiddleware.php
+++ b/test/Middleware/ValueMapperMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\Middleware\MapperMiddleware;
+use AutoMapperPlus\Middleware\Middleware;
+
+class ValueMapperMiddleware implements MapperMiddleware
+{
+    private $value;
+    private $supportsValue;
+
+    public function __construct($value = 'mapper middleware value', int $supportsValue = Middleware::AFTER)
+    {
+        $this->value = $value;
+        $this->supportsValue = $supportsValue;
+    }
+
+    public function supportsMap($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        return $this->supportsValue;
+    }
+
+    public function map($source, $destination, MappingInterface $mapping, array $context = [])
+    {
+        $destination->name = $this->value;
+    }
+}

--- a/test/Middleware/ValuePropertyMiddleware.php
+++ b/test/Middleware/ValuePropertyMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace AutoMapperPlus\Test\Middleware;
+
+
+use AutoMapperPlus\Configuration\MappingInterface;
+use AutoMapperPlus\MappingOperation\MappingOperationInterface;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Middleware\PropertyMiddleware;
+
+class ValuePropertyMiddleware implements PropertyMiddleware
+{
+    private $value;
+    private $supportsValue;
+
+    public function __construct($value = 'property middleware value', int $supportsValue = Middleware::AFTER)
+    {
+        $this->value = $value;
+        $this->supportsValue = $supportsValue;
+    }
+
+    public function supportsMapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        return $propertyName == 'name' ? $this->supportsValue : false;
+    }
+
+    public function mapProperty($propertyName, $source, $destination, MappingInterface $mapping, MappingOperationInterface $operation, array $context = [])
+    {
+        $destination->name = $this->value;
+    }
+}

--- a/test/Models/Employee/Employee.php
+++ b/test/Models/Employee/Employee.php
@@ -15,7 +15,7 @@ class Employee
     private $birthYear;
     private $address;
 
-    function __construct(int $id, string $firstName, string $lastName, int $birthYear, $address = null)
+    function __construct(?int $id, string $firstName, string $lastName, int $birthYear, $address = null)
     {
         $this->id = $id;
         $this->firstName = $firstName;

--- a/test/Models/SimpleProperties/CompleteSource.php
+++ b/test/Models/SimpleProperties/CompleteSource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AutoMapperPlus\Test\Models\SimpleProperties;
+
+/**
+ * Class CompleteSource
+ *
+ * @package AutoMapperPlus\Test\Models\SimpleProperties
+ */
+class CompleteSource
+{
+    public $name;
+
+    public $anotherProperty;
+
+    public function __construct($name = '', $anotherProperty = '')
+    {
+        $this->name = $name;
+        $this->anotherProperty = $anotherProperty;
+    }
+}

--- a/test/Scenarios/MiddlewareTest.php
+++ b/test/Scenarios/MiddlewareTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace AutoMapperPlus\Test\Scenarios;
+
+use AutoMapperPlus\AutoMapper;
+use AutoMapperPlus\Configuration\AutoMapperConfig;
+use AutoMapperPlus\Middleware\Middleware;
+use AutoMapperPlus\Test\Middleware\AnwserToUniverseMiddleware;
+use AutoMapperPlus\Test\Middleware\AppendMapperMiddleware;
+use AutoMapperPlus\Test\Middleware\AppendPropertyMiddleware;
+use AutoMapperPlus\Test\Middleware\BeforeMapperMiddleware;
+use AutoMapperPlus\Test\Middleware\BeforePropertyMiddleware;
+use AutoMapperPlus\Test\Middleware\NoopMapperMiddleware;
+use AutoMapperPlus\Test\Middleware\NoopPropertyMiddleware;
+use AutoMapperPlus\Test\Middleware\SkipMapperMiddleware;
+use AutoMapperPlus\Test\Middleware\SkipPropertyMiddleware;
+use AutoMapperPlus\Test\Middleware\ValueMapperMiddleware;
+use AutoMapperPlus\Test\Middleware\ValuePropertyMiddleware;
+use AutoMapperPlus\Test\Models\Employee\Employee;
+use AutoMapperPlus\Test\Models\Employee\EmployeeDto;
+use AutoMapperPlus\Test\Models\SimpleProperties\CompleteSource;
+use AutoMapperPlus\Test\Models\SimpleProperties\Destination;
+use AutoMapperPlus\Test\Models\SimpleProperties\Source;
+use PHPUnit\Framework\TestCase;
+
+class MiddlewareTest extends TestCase
+{
+    public function testValueMapperMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new ValueMapperMiddleware());
+        $config->registerMapping(Source::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new Source('a name');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('mapper middleware value', $result->name);
+    }
+
+    public function testValuePropertyMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new ValuePropertyMiddleware());
+        $config->registerMapping(CompleteSource::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new CompleteSource('a name', 'another property');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('property middleware value', $result->name);
+        $this->assertEquals('another property', $result->anotherProperty);
+    }
+
+    public function testAppendMapperMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new AppendMapperMiddleware());
+        $config->registerMapping(Source::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new Source('a name');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('a name (append)', $result->name);
+    }
+
+    public function testAppendPropertyMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new AppendPropertyMiddleware());
+        $config->registerMapping(CompleteSource::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new CompleteSource('a name', 'another property');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('a name (append)', $result->name);
+        $this->assertEquals('another property', $result->anotherProperty);
+    }
+
+    public function testBeforeNameMapperMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new BeforeMapperMiddleware());
+        $config->registerMapping(Source::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new Source('a name');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('a name', $result->name);
+    }
+
+    public function testBeforeNamePropertyMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new BeforePropertyMiddleware());
+        $config->registerMapping(CompleteSource::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new CompleteSource('a name', 'another property');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('a name', $result->name);
+        $this->assertEquals('another property', $result->anotherProperty);
+    }
+
+    public function testSkipMapperMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new SkipMapperMiddleware());
+        $config->registerMapping(Source::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new Source('a name');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('a name', $result->name);
+    }
+
+    public function testSkipPropertyMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new SkipPropertyMiddleware());
+        $config->registerMapping(CompleteSource::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new CompleteSource('a name', 'another property');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('a name', $result->name);
+        $this->assertEquals('This should happen unless it is name property', $result->anotherProperty);
+    }
+
+    public function testNoopMapperMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new NoopMapperMiddleware());
+        $config->registerMapping(Source::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new Source('a name');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertNull($result->name);
+    }
+
+    public function testNoopPropertyMiddleware()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new NoopPropertyMiddleware());
+        $config->registerMapping(CompleteSource::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new CompleteSource('a name', 'another property');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertNull($result->name);
+        $this->assertEquals('another property', $result->anotherProperty);
+    }
+
+    public function testManyMiddlewares()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(
+            new AppendPropertyMiddleware('mapper middleware value', Middleware::OVERRIDE),
+            new AppendMapperMiddleware('[before]', Middleware::BEFORE),
+            new AppendPropertyMiddleware('[before-property]', Middleware::BEFORE),
+            new AppendMapperMiddleware('[after]'),
+            new AppendPropertyMiddleware('[after-property]')
+        );
+        $config->registerMapping(CompleteSource::class, Destination::class);
+        $mapper = new AutoMapper($config);
+        $source = new CompleteSource('a name', 'another property');
+
+        /** @var Destination $result */
+        $result = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('[before][before-property]mapper middleware value[after-property][after]', $result->name);
+        $this->assertEquals('another property', $result->anotherProperty);
+    }
+
+    public function testAnswerToUniverse()
+    {
+        $config = new AutoMapperConfig();
+        $config->registerMiddlewares(new AnwserToUniverseMiddleware());
+        $config->registerMapping(Employee::class, EmployeeDto::class);
+        $config->registerMapping(
+            \AutoMapperPlus\Test\Models\SimilarPropertyNames\Source::class,
+            \AutoMapperPlus\Test\Models\SimilarPropertyNames\Destination::class
+        );
+
+        $mapper = new AutoMapper($config);
+        $source1 = new Employee(NULL, 'John', 'Doe', 1980);
+        $source2 = new \AutoMapperPlus\Test\Models\SimilarPropertyNames\Source(NULL, NULL);
+
+        /** @var EmployeeDto $result1 */
+        $result1 = $mapper->map($source1, EmployeeDto::class);
+        $this->assertEquals(42, $result1->id);
+        $this->assertEquals('John', $result1->firstName);
+        $this->assertEquals('Doe', $result1->lastName);
+
+        /**
+         * @var \AutoMapperPlus\Test\Models\SimilarPropertyNames\Destination $result2
+         */
+        $result2 = $mapper->map($source2, \AutoMapperPlus\Test\Models\SimilarPropertyNames\Destination::class);
+        $this->assertEquals(42, $result2->id);
+        $this->assertNull($result2->second_id);
+
+    }
+}


### PR DESCRIPTION
You can register middlewares to customize how automapper works internally and define
global behaviors.

The following example will set 42 to any `id` property that would have been `null`.

```php
<?php

class AnwserToUniverseMiddleware implements PropertyMiddleware
{
    public function supportsMapProperty($propertyName,
                                        $source,
                                        $destination,
                                        MappingInterface $mapping,
                                        MappingOperationInterface $operation,
                                        array $context = [])
    {
        return $propertyName == 'id';
    }

    public function mapProperty($propertyName,
                                $source,
                                $destination,
                                MappingInterface $mapping,
                                MappingOperationInterface $operation,
                                array $context = [])
    {
        $defaultValue = $mapping->getOptions()->getPropertyReader()->getProperty($destination, $propertyName);
        if ($defaultValue === NULL) {
            $mapping->getOptions()->getPropertyWriter()->setProperty($destination, $propertyName, 42);
        }
    }
}

$config->registerMiddlewares(new AnswerToLifeMiddleware());
$config->registerMapping(Employee::class, EmployeeDto::class);
$mapper = new AutoMapper($config);

// The AutoMapper can now be used as usual, but your custom mapper class will be
// called to do the actual mapping.
$employee = new Employee(NULL, 'John', 'Doe', 1980);
$result = $mapper->map($employee, EmployeeDto::class);
//$result->id = 42;
```

Middleware feature open up many extension capabilities, feel free to check PHPDocs 
from [PropertyMiddleware](./src/Middleware/PropertyMiddleware.php) and 
[MapperMiddleware](./src/Middleware/MapperMiddleware.php) interfaces for details.