### PR TITLE
Added syntactic sugar for extending mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Transfers data from one object to another, allowing custom mapping operations.
         * [ReverseMap](#reversemap)
         * [Copying a mapping](#copying-a-mapping)
     * [Automatic creation of mappings](#automatic-creation-of-mappings)
+    * [Extending already registered mappings](#extending-already-registered-mappings)
     * [Resolving property names](#resolving-property-names)
         * [Naming conventions](#naming-conventions)
         * [Explicitly state source property](#explicitly-state-source-property)
@@ -437,6 +438,24 @@ of mappings:
 <?php
 
 $config->getOptions()->createUnregisteredMappings();
+```
+
+With this configuration the mapper will generate a very basic mapping on the
+fly instead of throwing an exception if the mapping is not configured.
+
+### Extending already registered mappings
+There are some cases when you want to use unregistered mappings but you want to setup 
+mapping just for one or few properties of the mapped class without need to define mapping for 
+each property. In this case you can simply extend mapping and define just those properties
+that you need to have mapped differently:
+
+```php
+<?php
+
+$listMapping = $config->extendMapping(Employee::class, EmployeeListView::class)
+    ->forMember('name', function (Employee $employee) {
+        return strtoupper($employee->name);
+    });
 ```
 
 With this configuration the mapper will generate a very basic mapping on the

--- a/README.md
+++ b/README.md
@@ -458,9 +458,6 @@ $config->extendMapping(Employee::class, EmployeeListView::class)
     });
 ```
 
-With this configuration the mapper will generate a very basic mapping on the
-fly instead of throwing an exception if the mapping is not configured.
-
 ### Resolving property names
 Unless you define a specific way to fetch a value (e.g. `mapFrom`), the mapper
 has to have a way to know which source property to map from. By default, it will

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ that you need to have mapped differently:
 ```php
 <?php
 
-$listMapping = $config->extendMapping(Employee::class, EmployeeListView::class)
+$config->extendMapping(Employee::class, EmployeeListView::class)
     ->forMember('name', function (Employee $employee) {
         return strtoupper($employee->name);
     });

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Transfers data from one object to another, allowing custom mapping operations.
         * [ReverseMap](#reversemap)
         * [Copying a mapping](#copying-a-mapping)
     * [Automatic creation of mappings](#automatic-creation-of-mappings)
-    * [Extending already registered mappings](#extending-already-registered-mappings)
+    * [Extending mappings](#extending-mappings)
     * [Resolving property names](#resolving-property-names)
         * [Naming conventions](#naming-conventions)
         * [Explicitly state source property](#explicitly-state-source-property)
@@ -443,7 +443,7 @@ $config->getOptions()->createUnregisteredMappings();
 With this configuration the mapper will generate a very basic mapping on the
 fly instead of throwing an exception if the mapping is not configured.
 
-### Extending already registered mappings
+### Extending mappings
 There are some cases when you want to use unregistered mappings but you want to setup 
 mapping just for one or few properties of the mapped class without need to define mapping for 
 each property. In this case you can simply extend mapping and define just those properties

--- a/src/Configuration/AutoMapperConfig.php
+++ b/src/Configuration/AutoMapperConfig.php
@@ -205,6 +205,22 @@ class AutoMapperConfig implements AutoMapperConfigInterface
     /**
      * @inheritdoc
      */
+    public function extendMapping(
+        string $sourceClassName,
+        string $destinationClassName
+    ): MappingInterface {
+        if (!$this->hasMappingFor($sourceClassName, $destinationClassName)) {
+            throw new \RuntimeException("Undefined mapping for class $sourceClassName");
+        }
+
+        $mapping = $this->getMappingFor($sourceClassName, $destinationClassName);
+
+        return $this->registerMapping($sourceClassName, $destinationClassName)->copyFromMapping($mapping);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getOptions(): Options
     {
         return $this->options;

--- a/src/Configuration/AutoMapperConfigInterface.php
+++ b/src/Configuration/AutoMapperConfigInterface.php
@@ -48,6 +48,19 @@ interface AutoMapperConfigInterface
     ): MappingInterface;
 
     /**
+     * Extends already registered mapping. Whether it's unregistered type
+     * of mapping or manually registered mapping.
+     *
+     * @param string $sourceClassName
+     * @param string $destinationClassName
+     * @return MappingInterface
+     */
+    public function extendMapping(
+        string $sourceClassName,
+        string $destinationClassName
+    ): MappingInterface;
+
+    /**
      * @return Options
      */
     public function getOptions(): Options;

--- a/test/AutoMapperTest.php
+++ b/test/AutoMapperTest.php
@@ -150,6 +150,40 @@ class AutoMapperTest extends TestCase
         $this->assertEquals('NewName', $destination->name);
     }
 
+    public function testItCanExtendMapping()
+    {
+        $this->config->registerMapping(Source::class, Destination::class);
+        $mapper = new AutoMapper($this->config);
+        $source = new Source();
+        $source->name = 'John';
+        $destination = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('John', $destination->name);
+
+        $this->config->extendMapping(Source::class, Destination::class)
+            ->forMember('name', function (Source $source) {
+                return $source->name . ' ' . 'Doe';
+            });
+        $destination = $mapper->map($source, Destination::class);
+
+        $this->assertEquals('John Doe', $destination->name);
+    }
+
+    public function testItThrowsRuntimeErrorOnExtendMappingWhenDoesntHaveMapping()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $this->config->getOptions()->dontCreateUnregisteredMappings();
+        $mapper = new AutoMapper($this->config);
+        $this->config->extendMapping(Source::class, Destination::class)
+            ->forMember('name', function (Source $source) {
+                return $source->name . ' ' . 'Doe';
+            });
+        $source = new Source();
+        $source->name = 'John';
+        $mapper->map($source, Destination::class);
+    }
+
     public function testTheConfigurationCanBeRetrieved()
     {
         $config = new AutoMapperConfig();


### PR DESCRIPTION
Hi, I was working recently with this package which I really like and kept struggling in situation where I need to define just one property of mapped class. I'm using unregistered mappings in project so I thought that I'm gonna define mapping just for that one property and keep the rest as they were mapped by "unregistered mapping". So I did that and realised I need to define mapping for each property when registering mapping (which in this case is very verbose) because unregistered mappings are registered on fly. But then I realised that I can get that already unregistered mapping by [getMappingFor](https://github.com/mark-gerarts/automapper-plus/blob/master/src/Configuration/AutoMapperConfig.php#L53) method and then register mapping for my class and copy that unregistered mapping to it and then finally define mapping for my property where I need to define it's unique format. This way I achieved that all properties are mapped and I'm overriding already mapped properties. This took me some time because it was not really obvious for the first time from code.

So I thought it would be nice to have it in form of syntactic sugar as a method. As you see I prepared this PR based on my experience and it's fully backward compatible without any issues because it uses well known methods of this projects.

Thank you for response